### PR TITLE
Add Link property to Response class

### DIFF
--- a/Mastodon.API.Tests/Entities/AccountTest.cs
+++ b/Mastodon.API.Tests/Entities/AccountTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_account.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_account.json");
             var actual = JsonConvert.DeserializeObject<Account>(jsonString);
             var expected = new Account(
                 "29",

--- a/Mastodon.API.Tests/Entities/ApplicationTest.cs
+++ b/Mastodon.API.Tests/Entities/ApplicationTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using System;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_application.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_application.json");
             var actual = JsonConvert.DeserializeObject<Application>(jsonString);
             var expected = new Application("Amaroq", new Uri("https://appsto.re/us/OfFxib.i"));
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/AttachmentTest.cs
+++ b/Mastodon.API.Tests/Entities/AttachmentTest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_attachment.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_attachment.json");
             var actual = JsonConvert.DeserializeObject<Attachment>(jsonString);
             var expected = new Attachment(
                 "39071",

--- a/Mastodon.API.Tests/Entities/CardTest.cs
+++ b/Mastodon.API.Tests/Entities/CardTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using System;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_card.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_card.json");
             var actual = JsonConvert.DeserializeObject<Card>(jsonString);
             var expected = new Card(
                 new Uri("http://seiga.nicovideo.jp/comic/20782"),

--- a/Mastodon.API.Tests/Entities/ErrorTest.cs
+++ b/Mastodon.API.Tests/Entities/ErrorTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using System;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_error.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_error.json");
             var actual = JsonConvert.DeserializeObject<Error>(jsonString);
             var expected = new Error("Record not found");
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/InstanceTest.cs
+++ b/Mastodon.API.Tests/Entities/InstanceTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using Newtonsoft.Json;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_instance.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_instance.json");
             var actual = JsonConvert.DeserializeObject<Instance>(jsonString);
             var expected = new Instance("friends.nico", "friends.nico", "test", "test@test.nico");
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/MastodonAppTest.cs
+++ b/Mastodon.API.Tests/Entities/MastodonAppTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_mastodon_app.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_mastodon_app.json");
             var actual = JsonConvert.DeserializeObject<MastodonApp>(jsonString);
             var expected = new MastodonApp(
                 "0",

--- a/Mastodon.API.Tests/Entities/MentionTest.cs
+++ b/Mastodon.API.Tests/Entities/MentionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_mention.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_mention.json");
             var actual = JsonConvert.DeserializeObject<Mention>(jsonString);
             var expected = new Mention(
                 new Uri("https://friends.nico/@gomi_ningen"),

--- a/Mastodon.API.Tests/Entities/RelationshipTest.cs
+++ b/Mastodon.API.Tests/Entities/RelationshipTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -11,7 +11,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_relationship.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_relationship.json");
             var actual = JsonConvert.DeserializeObject<Relationship>(jsonString);
             var expected = new Relationship("29", true, true, true, true, true);
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/ReportTest.cs
+++ b/Mastodon.API.Tests/Entities/ReportTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -11,7 +11,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_report.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_report.json");
             var actual = JsonConvert.DeserializeObject<Report>(jsonString);
             var expected = new Report("101", true);
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/StatusTest.cs
+++ b/Mastodon.API.Tests/Entities/StatusTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -11,7 +11,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_status.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_status.json");
             var actual = JsonConvert.DeserializeObject<Status>(jsonString);
             var expected = new Status(
                 "622216",

--- a/Mastodon.API.Tests/Entities/TagTest.cs
+++ b/Mastodon.API.Tests/Entities/TagTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using System;
 
@@ -10,7 +10,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_tag.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_tag.json");
             var actual = JsonConvert.DeserializeObject<Tag>(jsonString);
             var expected = new Tag("test1", new Uri("https://friends.nico/tags/test1"));
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/Entities/TokenTest.cs
+++ b/Mastodon.API.Tests/Entities/TokenTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 
 namespace Mastodon.API.Tests
@@ -9,7 +9,7 @@ namespace Mastodon.API.Tests
         [Test]
         public void DeserializeTest()
         {
-            var jsonString = EntityTestUtils.getJsonString("Mastodon.API.Tests.Resources.get_token.json");
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_token.json");
             var actual = JsonConvert.DeserializeObject<Token>(jsonString);
             var expected = new Token("aiueo", "bearer", "read", "1492791762");
             Assert.AreEqual(expected, actual);

--- a/Mastodon.API.Tests/LinkTest.cs
+++ b/Mastodon.API.Tests/LinkTest.cs
@@ -1,0 +1,53 @@
+using System;
+using NUnit.Framework;
+using System.Net.Http.Headers;
+using System.Net;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Reflection;
+
+namespace Mastodon.API.Tests
+{
+    [TestFixture]
+    public class LinkTest
+    {
+        [Test]
+        public void createNextAndPrevLinkTest()
+        {
+            var str = TestUtils.GetResource("Mastodon.API.Tests.Resources.next_and_prev_link");
+            var link = Link.CreateLinkFromHeaderLinkValue(str);
+            Assert.NotNull(link);
+            Assert.AreEqual(1860868, link.Value.MaxId);
+            Assert.AreEqual(1874433, link.Value.SinceId);
+        }
+
+        [Test]
+        public void createNextLinkTest()
+        {
+            var str = TestUtils.GetResource("Mastodon.API.Tests.Resources.next_link");
+            var link = Link.CreateLinkFromHeaderLinkValue(str);
+            Assert.NotNull(link);
+            Assert.AreEqual(1860868, link.Value.MaxId);
+            Assert.Null(link.Value.SinceId);
+        }
+
+        [Test]
+        public void createPrevLinkTest()
+        {
+            var str = TestUtils.GetResource("Mastodon.API.Tests.Resources.prev_link");
+            var link = Link.CreateLinkFromHeaderLinkValue(str);
+            Assert.NotNull(link);
+            Assert.Null(link.Value.MaxId);
+            Assert.AreEqual(1874433, link.Value.SinceId);
+        }
+
+        [Test]
+        public void createLinkTestWithEmptyString()
+        {
+            var str = "";
+            var link = Link.CreateLinkFromHeaderLinkValue(str);
+            Assert.Null(link);
+        }
+    }
+}

--- a/Mastodon.API.Tests/Mastodon.API.Tests.csproj
+++ b/Mastodon.API.Tests/Mastodon.API.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Entities\StatusVisibilityTest.cs" />
     <Compile Include="ApiClientBaseTest.cs" />
     <Compile Include="TestUtils.cs" />
+    <Compile Include="LinkTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -83,6 +84,9 @@
     <EmbeddedResource Include="Resources\get_status.json" />
     <EmbeddedResource Include="Resources\get_token.json" />
     <EmbeddedResource Include="Resources\get_mastodon_app.json" />
+    <EmbeddedResource Include="Resources\next_and_prev_link" />
+    <EmbeddedResource Include="Resources\prev_link" />
+    <EmbeddedResource Include="Resources\next_link" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Mastodon.API.Tests/Mastodon.API.Tests.csproj
+++ b/Mastodon.API.Tests/Mastodon.API.Tests.csproj
@@ -51,10 +51,10 @@
     <Compile Include="Entities\TokenTest.cs" />
     <Compile Include="ExtensionsTest.cs" />
     <Compile Include="Entities\MastodonAppTest.cs" />
-    <Compile Include="Entities\EntityTestUtils.cs" />
     <Compile Include="Entities\OAuthAccessScopeTest.cs" />
     <Compile Include="Entities\StatusVisibilityTest.cs" />
     <Compile Include="ApiClientBaseTest.cs" />
+    <Compile Include="TestUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Mastodon.API.Tests/Resources/next_and_prev_link
+++ b/Mastodon.API.Tests/Resources/next_and_prev_link
@@ -1,0 +1,1 @@
+﻿<https://example.com/api/v1/accounts/0/statuses?max_id=1860868>; rel="next", <https://example.com/api/v1/accounts/0/statuses?since_id=1874433>; rel="prev"

--- a/Mastodon.API.Tests/Resources/next_link
+++ b/Mastodon.API.Tests/Resources/next_link
@@ -1,0 +1,1 @@
+﻿<https://example.com/api/v1/accounts/0/statuses?max_id=1860868>; rel="next"

--- a/Mastodon.API.Tests/Resources/prev_link
+++ b/Mastodon.API.Tests/Resources/prev_link
@@ -1,0 +1,1 @@
+﻿<https://example.com/api/v1/accounts/0/statuses?since_id=1874433>; rel="prev"

--- a/Mastodon.API.Tests/TestUtils.cs
+++ b/Mastodon.API.Tests/TestUtils.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 
 namespace Mastodon.API.Tests
 {
-    static class EntityTestUtils
+    static class TestUtils
     {
-        internal static string getJsonString(string resourceName)
+        internal static string GetResource(string resourceName)
         {
             var assembly = typeof(AccountTest).GetTypeInfo().Assembly;
             var stream = assembly.GetManifestResourceStream(resourceName);

--- a/Mastodon.API/Link.cs
+++ b/Mastodon.API/Link.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿using System.Linq;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+
 namespace Mastodon.API
 {
     public struct Link
@@ -15,10 +19,17 @@ namespace Mastodon.API
         /// <value>The since identifier.</value>
         public int? SinceId { get; }
 
-        public static Link? create(int? maxId = null, int? sinceId = null)
+        public static Link? Create(int? maxId = null, int? sinceId = null)
         {
             if (maxId.HasValue || sinceId.HasValue) return new Link(maxId, sinceId);
             return null;
+        }
+
+        public static Link? Create(HttpHeaders headers)
+        {
+            var linkHeader = GetValueFromHeaders("Link", headers);
+            if (linkHeader == null) return null;
+            return CreateLinkFromHeaderLinkValue(linkHeader);
         }
 
         Link(int? maxId, int? sinceId)
@@ -30,7 +41,7 @@ namespace Mastodon.API
         public override bool Equals(object obj)
         {
             if (!(obj is Link)) return false;
-            var o = (Link) obj;
+            var o = (Link)obj;
             return Equals(MaxId, o.MaxId) &&
                 Equals(SinceId, o.SinceId);
         }
@@ -43,6 +54,31 @@ namespace Mastodon.API
         public override string ToString()
         {
             return string.Format("[Link: MaxId={0}, SinceId={1}]", MaxId, SinceId);
+        }
+
+        internal static string GetValueFromHeaders(string key, HttpHeaders headers)
+        {
+            if (headers == null) return null;
+            return headers
+                .Where(x => x.Key.Equals(key))
+                .Select(x => x.Value)
+                .First().First();
+        }
+
+        internal static Link? CreateLinkFromHeaderLinkValue(string headerLinkValue)
+        {
+            if (headerLinkValue == null) return null;
+            var kvs = headerLinkValue.Split(',')
+                       .Select(x => Regex.Match(x, "<http.+[&|?](max_id|since_id)=(\\d+).*>;\\s*rel=\"(next|prev)\"").Groups)
+                       .Select(x => new KeyValuePair<string, string>(x[1].ToString(), x[2].ToString()));
+            int? maxId = null;
+            int? sinceId = null;
+            foreach (var kv in kvs)
+            {
+                if (kv.Key.Equals("max_id")) maxId = int.Parse(kv.Value);
+                if (kv.Key.Equals("since_id")) sinceId = int.Parse(kv.Value);
+            }
+            return Create(maxId, sinceId);
         }
     }
 }

--- a/Mastodon.API/Response.cs
+++ b/Mastodon.API/Response.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 namespace Mastodon.API
 {
     public class Response<T>
     {
         public T Resource { get; }
         public HttpResponseMessage Message { get; }
+        public Link? Link { get; }
 
         public Response(T resource, HttpResponseMessage message)
         {
             Resource = resource;
             Message = message;
+            Link = API.Link.Create(message.Headers);
         }
 
         public override string ToString()


### PR DESCRIPTION
enable getting next/prev link from array response easily.

* https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#selecting-ranges
* https://tools.ietf.org/html/rfc5988