### PR TITLE
Exception on some unit tests

### DIFF
--- a/Mastodon.API.Tests/Entities/AccountTest.cs
+++ b/Mastodon.API.Tests/Entities/AccountTest.cs
@@ -26,8 +26,8 @@ namespace Mastodon.API.Tests
                 new Uri("https://friends.nico/@gomi_ningen"),
                 null,
                 null,
-                new Uri("/headers/original/missing.png"),
-                new Uri("/headers/original/missing.png")
+                new Uri("/headers/original/missing.png", UriKind.Relative),
+                new Uri("/headers/original/missing.png", UriKind.Relative)
             );
             Assert.AreEqual(expected, actual);
             actual.GetHashCode();

--- a/Mastodon.API.Tests/Entities/StatusTest.cs
+++ b/Mastodon.API.Tests/Entities/StatusTest.cs
@@ -32,8 +32,8 @@ namespace Mastodon.API.Tests
                     // fixme
                     null, //new Uri("https://d2zoeobnny43zx.cloudfront.net/accounts/avatars/000/000/029/original/bc840deef1c57f8f.png?1492587071"),
                     null, //new Uri("https://d2zoeobnny43zx.cloudfront.net/accounts/avatars/000/000/029/original/bc840deef1c57f8f.png?1492587071"),
-                    new Uri("/headers/original/missing.png"),
-                    new Uri("/headers/original/missing.png")
+                    new Uri("/headers/original/missing.png", UriKind.Relative),
+                    new Uri("/headers/original/missing.png", UriKind.Relative)
                 ),
                 null,
                 null,


### PR DESCRIPTION
While I was attempting to run unit tests, I ran into the following exception

> Invalid URI: The format of the URI could not be determined.

I found that by changing the way the Uri objects were declared to be relative that the unit tests then passed.  It could make a difference that I'm running on VS Community 2017, but these changes should be compatible with other versions as well.  I just wonder if this is an indicator I could run into similar issues in other parts of the code.