### PR TITLE
HttpClient as an optional parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+
+# VS 2017
+.vs

--- a/Mastodon.API.Tests/MastodonApiTest.cs
+++ b/Mastodon.API.Tests/MastodonApiTest.cs
@@ -4,17 +4,23 @@ using NUnit.Framework;
 
 namespace Mastodon.API.Tests
 {
-    //[TestFixture]
-    //public class MastodonApiTest
-    //{
-    //    [Test]
-    //    public void Test()
-    //    {
-    //        var http = new HttpClient();
-    //        var config = new MastodonApiConfig(new Uri("https://friends.nico"), "");
-    //        var api = new MastodonApi(config, http);
-    //        var account = api.GetFollowers("29", limit: 13).Result;
-    //        Console.WriteLine(account.Length);
-    //    }
-    //}
+    [TestFixture]
+    public class MastodonApiTest
+    {
+        //[Test]
+        //public void Test()
+        //{
+        //    var http = new HttpClient();
+        //    var config = new MastodonApiConfig(new Uri("https://friends.nico"), "");
+        //    var api = new MastodonApi(config, http);
+        //    var account = api.GetFollowers("29", limit: 13).Result;
+        //    Console.WriteLine(account.Length);
+        //}
+
+        [Test]
+        public void GetDefaultHttpClient_DoesNotReturnNull()
+        {
+            Assert.NotNull(MastodonApi.GetDefaultHttpClient());
+        }
+    }
 }

--- a/Mastodon.API/ApiClientBase.cs
+++ b/Mastodon.API/ApiClientBase.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Mastodon.API
 {
-    class ApiClientBase
+    class ApiClientBase : IDisposable
     {
         readonly Uri baseUrl;
         readonly HttpClient http;
@@ -101,6 +101,11 @@ namespace Mastodon.API
         public override int GetHashCode()
         {
             return Object.GetHashCode(baseUrl, http);
+        }
+
+        public void Dispose()
+        {
+            http.Dispose();
         }
     }
 }

--- a/Mastodon.API/MastodonApi.cs
+++ b/Mastodon.API/MastodonApi.cs
@@ -8,16 +8,16 @@ using System.Linq;
 
 namespace Mastodon.API
 {
-    public class MastodonApi : IMastodonApi
+    public class MastodonApi : IMastodonApi, IDisposable
     {
         readonly ApiClientBase apiBase;
         readonly MastodonApiConfig config;
         readonly Dictionary<string, string> authorizationHeader;
 
-        public MastodonApi(MastodonApiConfig config, HttpClient httpClient)
+        public MastodonApi(MastodonApiConfig config, HttpClient httpClient = null)
         {
             this.config = config;
-            apiBase = new ApiClientBase(config.InstanceUrl, httpClient);
+            apiBase = new ApiClientBase(config.InstanceUrl, httpClient ?? MastodonApi.GetDefaultHttpClient());
             authorizationHeader = new Dictionary<string, string> { { "Authorization", $"Bearer {config.AccessToken}" } };
         }
 
@@ -509,6 +509,16 @@ namespace Mastodon.API
                 .Content.ReadAsStringAsync()
                 .ContinueWith((task) => JsonConvert.DeserializeObject<Status[]>(task.Result));
             return new Response<Status[]>(resource, response);
+        }
+
+        internal static HttpClient GetDefaultHttpClient()
+        {
+            return new HttpClient();
+        }
+
+        public void Dispose()
+        {
+            apiBase.Dispose();
         }
     }
 }

--- a/Mastodon.API/MastodonAuthClient.cs
+++ b/Mastodon.API/MastodonAuthClient.cs
@@ -8,13 +8,13 @@ using System.Net.Http.Headers;
 
 namespace Mastodon.API
 {
-    public class MastodonAuthClient
+    public class MastodonAuthClient : IDisposable
     {
         readonly ApiClientBase apiBase;
 
-        public MastodonAuthClient(Uri instanceUrl, HttpClient httpClient)
+        public MastodonAuthClient(Uri instanceUrl, HttpClient httpClient = null)
         {
-            apiBase = new ApiClientBase(instanceUrl, httpClient);
+            apiBase = new ApiClientBase(instanceUrl, httpClient ?? MastodonApi.GetDefaultHttpClient());
         }
 
         /// <summary>
@@ -61,6 +61,11 @@ namespace Mastodon.API
             return await response
                 .Content.ReadAsStringAsync()
                 .ContinueWith((task) => JsonConvert.DeserializeObject<Token>(task.Result));
+        }
+
+        public void Dispose()
+        {
+            apiBase.Dispose();
         }
     }
 }


### PR DESCRIPTION
This change does the following:

- Makes HttpClient optional for both MastodonApi and MastodonAuthClient classes
- Calls into MastodonApi.GetDefaultHttpClient() if HttpClient is null
- An additional unit test that check to assure MastodonApi.GetDefaultHttpClient() isn't returning null.