### PR TITLE
Error handling improvements

### DIFF
--- a/Mastodon.API.Tests/ApiClientBaseTest.cs
+++ b/Mastodon.API.Tests/ApiClientBaseTest.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using Mastodon.API.Tests.Mocks;
 
 
@@ -62,6 +63,49 @@ namespace Mastodon.API.Tests
         }
 
         [Test]
+        public async void CheckResponseWithStatusOKReturnsSameResponse()
+        {
+            var testResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK
+            };
+
+            var result = await ApiClientBase.CheckResponse(testResponse);
+            Assert.AreSame(testResponse, result);
+        }
+
+        [Test]
+        public void CheckResponseWithFailStatusAndErrorBodyThrowsMastodonApiExceptionWithParsedError()
+        {
+            var jsonString = TestUtils.GetResource("Mastodon.API.Tests.Resources.get_error.json");
+            var expectedError = new Error("Record not found");
+            var testResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Content = new StringContent(jsonString)
+            };
+            Assert.That(async () => await ApiClientBase.CheckResponse(testResponse),
+                Throws.Exception.TypeOf<MastodonApiException>()
+                .With.Property("Error").EqualTo(expectedError)
+                .With.Property("StatusCode").EqualTo(HttpStatusCode.NotFound));
+        }
+
+        [Test]
+        public void CheckResponseWithFailStatusButNoParsableErrorBodyThrowsMastodonApiExceptionWithBodyInMessage()
+        {
+            var errorMessage = "History eraser button pressed";
+            var testResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(errorMessage)
+            };
+            Assert.That(async () => await ApiClientBase.CheckResponse(testResponse),
+                Throws.Exception.TypeOf<MastodonApiException>()
+                .With.Property("Message").EqualTo($"Unexpected error returned from server: {errorMessage}")
+                .With.Property("StatusCode").EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
         public async void GetAsyncWithStatusAndMessage()
         {
             var message = "Hello";
@@ -83,7 +127,7 @@ namespace Mastodon.API.Tests
             var mockHttp = MockHttpClient.Create(message, statusCode);
             var apiClient = new ApiClientBase(new Uri("http://example.com/"), mockHttp);
 
-            Assert.Throws<System.Net.Http.HttpRequestException>(async () => await apiClient.GetAsync("/test"));
+            Assert.Throws<MastodonApiException>(async () => await apiClient.GetAsync("/test"));
         }
     }
 }

--- a/Mastodon.API.Tests/ApiClientBaseTest.cs
+++ b/Mastodon.API.Tests/ApiClientBaseTest.cs
@@ -67,12 +67,23 @@ namespace Mastodon.API.Tests
             var message = "Hello";
             var statusCode = HttpStatusCode.OK;
             var mockHttp = MockHttpClient.Create(message, statusCode);
-            var apiClient = new ApiClientBase(new Uri("http://example.com/"), MockHttpClient.Create(message, statusCode));
+            var apiClient = new ApiClientBase(new Uri("http://example.com/"), mockHttp);
 
             var response = await apiClient.GetAsync("/test");
 
             Assert.AreEqual(message, await response.Content.ReadAsStringAsync());
             Assert.AreEqual(statusCode, response.StatusCode);
+        }
+
+        [Test]
+        public void GetAsyncWithBadRequest()
+        {
+            var message = "This was bad";
+            var statusCode = HttpStatusCode.BadRequest;
+            var mockHttp = MockHttpClient.Create(message, statusCode);
+            var apiClient = new ApiClientBase(new Uri("http://example.com/"), mockHttp);
+
+            Assert.Throws<System.Net.Http.HttpRequestException>(async () => await apiClient.GetAsync("/test"));
         }
     }
 }

--- a/Mastodon.API.Tests/ApiClientBaseTest.cs
+++ b/Mastodon.API.Tests/ApiClientBaseTest.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Net;
+using Mastodon.API.Tests.Mocks;
+
 
 namespace Mastodon.API.Tests
 {
@@ -56,6 +59,20 @@ namespace Mastodon.API.Tests
             var baseUrl = new Uri("https://friends.nico/");
             var actual = ApiClientBase.createUrl(baseUrl, null, null);
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public async void GetAsyncWithStatusAndMessage()
+        {
+            var message = "Hello";
+            var statusCode = HttpStatusCode.OK;
+            var mockHttp = MockHttpClient.Create(message, statusCode);
+            var apiClient = new ApiClientBase(new Uri("http://example.com/"), MockHttpClient.Create(message, statusCode));
+
+            var response = await apiClient.GetAsync("/test");
+
+            Assert.AreEqual(message, await response.Content.ReadAsStringAsync());
+            Assert.AreEqual(statusCode, response.StatusCode);
         }
     }
 }

--- a/Mastodon.API.Tests/Mastodon.API.Tests.csproj
+++ b/Mastodon.API.Tests/Mastodon.API.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,6 +54,8 @@
     <Compile Include="Entities\OAuthAccessScopeTest.cs" />
     <Compile Include="Entities\StatusVisibilityTest.cs" />
     <Compile Include="ApiClientBaseTest.cs" />
+    <Compile Include="Mocks\MockHttpClient.cs" />
+    <Compile Include="Mocks\MockHttpMessageHandler.cs" />
     <Compile Include="TestUtils.cs" />
     <Compile Include="LinkTest.cs" />
   </ItemGroup>
@@ -66,10 +68,7 @@
       <Name>Mastodon.API</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Entities\" />
-    <Folder Include="Resources\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <EmbeddedResource Include="Resources\get_account.json" />
     <EmbeddedResource Include="Resources\get_instance.json" />
@@ -87,6 +86,9 @@
     <EmbeddedResource Include="Resources\next_and_prev_link" />
     <EmbeddedResource Include="Resources\prev_link" />
     <EmbeddedResource Include="Resources\next_link" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Mastodon.API.Tests/Mastodon.API.Tests.csproj
+++ b/Mastodon.API.Tests/Mastodon.API.Tests.csproj
@@ -68,7 +68,11 @@
       <Name>Mastodon.API</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Entities\" />
+    <Folder Include="Mocks\" />
+    <Folder Include="Resources\" />
+  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\get_account.json" />
     <EmbeddedResource Include="Resources\get_instance.json" />
@@ -86,9 +90,6 @@
     <EmbeddedResource Include="Resources\next_and_prev_link" />
     <EmbeddedResource Include="Resources\prev_link" />
     <EmbeddedResource Include="Resources\next_link" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Mastodon.API.Tests/Mocks/MockHttpClient.cs
+++ b/Mastodon.API.Tests/Mocks/MockHttpClient.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
+
+namespace Mastodon.API.Tests.Mocks
+{
+    class MockHttpClient
+    {
+        /// <summary>
+        /// Will create an HttpClient using the MockHttpMessageHandler to force the client to ALWAYS return the
+        /// same message.  Can be good for testing single calls to force certain execution paths without having
+        /// to touch the real web server
+        /// </summary>
+        /// <param name="message">Message that will be returned in the response</param>
+        /// <param name="statusCode">The standard HTTP Status Code that will be returned</param>
+        /// <returns></returns>
+        public static HttpClient Create(string message, HttpStatusCode statusCode)
+        {
+            return new HttpClient(new MockHttpMessageHandler(message, statusCode));
+        }
+    }
+}

--- a/Mastodon.API.Tests/Mocks/MockHttpMessageHandler.cs
+++ b/Mastodon.API.Tests/Mocks/MockHttpMessageHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+
+namespace Mastodon.API.Tests.Mocks
+{
+    class MockHttpMessageHandler : HttpClientHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public MockHttpMessageHandler(string message, HttpStatusCode statusCode)
+        {
+            _response = new HttpResponseMessage()
+            {
+                Content = new StringContent(message),
+                StatusCode = statusCode
+            };
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<HttpResponseMessage>(_response);
+        }
+    }
+}

--- a/Mastodon.API/Mastodon.API.csproj
+++ b/Mastodon.API/Mastodon.API.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,6 +29,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="MastodonApiException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Entities\Account.cs" />
     <Compile Include="Entities\Application.cs" />
@@ -57,9 +58,7 @@
     <Compile Include="ApiClientBase.cs" />
     <Compile Include="Entities\StatusVisibility.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Entities\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\portable-net45+win8+wpa81+wp8\Newtonsoft.Json.dll</HintPath>

--- a/Mastodon.API/MastodonApiException.cs
+++ b/Mastodon.API/MastodonApiException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+
+namespace Mastodon.API
+{
+    /// <summary>
+    /// This exception indicates an error code from the MastodonAPI (i.e., 400, 404, 500, etc).
+    /// It is up to the caller to catch these exceptions and take appropriate action within their application.
+    /// </summary>
+    public class MastodonApiException : Exception
+    {
+        /// <summary>
+        /// The StatusCode returned from the Http call to the API
+        /// </summary>
+        public HttpStatusCode StatusCode { get; }
+        /// <summary>
+        /// Deserialized representation of the error message from the API
+        /// </summary>
+        public Error Error { get; set; }
+
+        public MastodonApiException(HttpStatusCode statusCode, Error error)
+        {
+            StatusCode = statusCode;
+            Error = error;
+        }
+
+        public MastodonApiException(HttpStatusCode statusCode, string message)
+            : base(message)
+        {
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/Mastodon.API/MastodonApiException.cs
+++ b/Mastodon.API/MastodonApiException.cs
@@ -20,7 +20,7 @@ namespace Mastodon.API
         /// <summary>
         /// Deserialized representation of the error message from the API
         /// </summary>
-        public Error Error { get; set; }
+        public Error Error { get; }
 
         public MastodonApiException(HttpStatusCode statusCode, Error error)
         {


### PR DESCRIPTION
Issue #24.  This changes the exception being thrown when there is a failure response code to MastodonApiException, containing additional information to help the developer respond to particular error conditions.

Also included is some additional unit testing using a mock HttpClient, which we may want to expand upon to get some additional test coverage.