### PR TITLE
Rename method OAuthAccessScope.of to OAuthAccessScope.Of

### DIFF
--- a/Mastodon.API.Tests/Entities/OAuthAccessScopeTest.cs
+++ b/Mastodon.API.Tests/Entities/OAuthAccessScopeTest.cs
@@ -9,13 +9,13 @@ namespace Mastodon.API.Tests
         [Test]
         public void ValueTest()
         {
-            Assert.AreEqual("read", OAuthAccessScope.of(OAtuhAccessScopeType.Read).Value);
-            Assert.AreEqual("write", OAuthAccessScope.of(OAtuhAccessScopeType.Write).Value);
-            Assert.AreEqual("follow", OAuthAccessScope.of(OAtuhAccessScopeType.Follow).Value);
-            Assert.AreEqual("read", OAuthAccessScope.of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Read).Value);
-            Assert.AreEqual("read write", OAuthAccessScope.of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write).Value);
-            Assert.AreEqual("read write follow", OAuthAccessScope.of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write, OAtuhAccessScopeType.Follow).Value);
-            Assert.AreEqual("read write follow", OAuthAccessScope.of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write, OAtuhAccessScopeType.Follow, OAtuhAccessScopeType.Read).Value);
+            Assert.AreEqual("read", OAuthAccessScope.Of(OAtuhAccessScopeType.Read).Value);
+            Assert.AreEqual("write", OAuthAccessScope.Of(OAtuhAccessScopeType.Write).Value);
+            Assert.AreEqual("follow", OAuthAccessScope.Of(OAtuhAccessScopeType.Follow).Value);
+            Assert.AreEqual("read", OAuthAccessScope.Of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Read).Value);
+            Assert.AreEqual("read write", OAuthAccessScope.Of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write).Value);
+            Assert.AreEqual("read write follow", OAuthAccessScope.Of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write, OAtuhAccessScopeType.Follow).Value);
+            Assert.AreEqual("read write follow", OAuthAccessScope.Of(OAtuhAccessScopeType.Read, OAtuhAccessScopeType.Write, OAtuhAccessScopeType.Follow, OAtuhAccessScopeType.Read).Value);
         }
     }
 }

--- a/Mastodon.API/Entities/OAuthAccessScope.cs
+++ b/Mastodon.API/Entities/OAuthAccessScope.cs
@@ -9,7 +9,7 @@ namespace Mastodon.API
     {
         IEnumerable<OAtuhAccessScopeType> types;
 
-        public static OAuthAccessScope of(params OAtuhAccessScopeType[] types)
+        public static OAuthAccessScope Of(params OAtuhAccessScopeType[] types)
         {
             return new OAuthAccessScope(types);
         }


### PR DESCRIPTION
* see: https://msdn.microsoft.com/library/ms229043(v=vs.110).aspx
* contains breaking change